### PR TITLE
Change the danger scaling and default values

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -11,8 +11,10 @@ namespace game {
      */
     //% block="set strength of wind to $num"
     //% num.defl=3
+    //% num.min=0
+    //% num.max=10
     export function set_strength_of_wind(num: number) {
-        forestFire.setWindSpeed(num);
+        forestFire.setWindSpeed(Math.clamp(0, 10, num));
     }
 
     /*
@@ -21,8 +23,10 @@ namespace game {
      */
     //% block="set health of trees to $num"
     //% num.defl=7
+    //% num.min=0
+    //% num.max=10
     export function set_health_of_trees(num: number) {
-        forestFire.setTinder(num);
+        forestFire.setTreeHealth(Math.clamp(0, 10, num));
     }
 
     /*
@@ -31,8 +35,10 @@ namespace game {
      */
     //% block="set dryness of grass to $num"
     //% num.defl=3
+    //% num.min=0
+    //% num.max=10
     export function set_dryness_of_grass(num: number) {
-        forestFire.setDryGrass(num);
+        forestFire.setDryGrass(Math.clamp(0, 10, num));
     }
 }
 
@@ -46,7 +52,7 @@ namespace sprites {
     //% block="set strength of fire at $location to $health"
     //% location.shadow=variables_get
     //% location.defl=location
-    //% health.defl=10
+    //% health.defl=5
     export function set_flame_strength(location: tiles.Location, health: number) {
         forestFire.setFireHealth(location, health)
     }
@@ -133,7 +139,7 @@ namespace sprites {
     }
 
     /**
-     * 
+     *
      */
     //% block="create spreading fire on random $onTile with image $burningTile"
     //% onTile.shadow=tileset_tile_picker

--- a/fire.ts
+++ b/fire.ts
@@ -12,7 +12,7 @@ namespace forestFire {
         fireImage: Image;
 
         windSpeed: number;
-        tinder: number;
+        treeHealth: number;
         dryGrass: number;
 
         fireCreatedHandlers: ((location: tiles.Location) => void)[];
@@ -44,7 +44,7 @@ namespace forestFire {
             this.fireDestroyedHandlers = [];
 
             this.windSpeed = 5;
-            this.tinder = 4;
+            this.treeHealth = 4;
             this.dryGrass = 5;
 
             this.fireHasStarted = false;
@@ -79,11 +79,11 @@ namespace forestFire {
                 hud.updateForestHealth(totalTrees, unburntTrees);
                 hud.updateFireNumber(activeFires)
 
-                if (this.spreadTime >= 4000) {
+                if (this.danger < 2.5) {
                     hud.updateDangerBarColors(7)
-                } else if (this.spreadTime >= 3000) {
+                } else if (this.danger < 5) {
                     hud.updateDangerBarColors(5)
-                } else if (this.spreadTime >= 2000) {
+                } else if (this.danger < 7.5) {
                     hud.updateDangerBarColors(4)
                 } else {
                     hud.updateDangerBarColors(2)
@@ -98,8 +98,12 @@ namespace forestFire {
             })
         }
 
+        get danger() {
+            return (this.windSpeed + this.dryGrass + (10 - this.treeHealth)) / 3
+        }
+
         get spreadTime() {
-            return 4500 - this.windSpeed * 250 - this.dryGrass * 250 - this.tinder * 100;
+            return 4500 - (this.danger / 10) * 3500;
         }
 
         getRandomSpreadInterval() {
@@ -176,6 +180,8 @@ namespace forestFire {
             // Loop over every location in the timeBuffer and update the times
             for (let x = 0; x < this.timeBuffer.width; x++) {
                 for (let y = 0; y < this.timeBuffer.height; y++) {
+                    if (Math.percentChance(30 * (10 - this.danger) / 10)) continue;
+
                     current = this.timeBuffer.getPixel(x, y);
 
                     // If the value is 0, the fire hasn't started yet
@@ -289,8 +295,8 @@ namespace forestFire {
         state.dryGrass = grass;
     }
 
-    export function setTinder(tinder: number) {
-        state.tinder = tinder;
+    export function setTreeHealth(treeHealth: number) {
+        state.treeHealth = treeHealth;
     }
 
     export function setFireHealth(location: tiles.Location, health: number) {


### PR DESCRIPTION
Fixes part of https://github.com/microsoft/pxt-arcade/issues/4212#event-5507452227
Fixes https://github.com/microsoft/pxt-arcade/issues/4223
Fixes https://github.com/microsoft/pxt-arcade/issues/4224

Changes the danger scaling logic to make things a bit easier to understand. Basically, I'm taking the average of the three values (with tree health being scaled so that lower values are worse) using this formula:

```
dangerPercentage = (dryness + wind + (10 - treeHealth)) / 3
```
Here are breakpoints for the danger scale:

* danger < 2.5 is green
* danger >= 2.5 and < 5 is yellow
* danger >= 5 and < 7.5 is orange
* danger >= 7.5 is red

I did a few tests:

* Worst case (dryness = 10, wind = 10, treeHealth = 1) takes about 15 seconds to fill the map with fire
* Average case (dryness = 5, wind = 5, treeHealth = 5) takes about 30 seconds to fill the map with fire
* Best case (dryness = 1, wind = 1, treeHealth = 10) takes about 55 seconds to fill the map with fire


This PR also sets the min/max for each of these values. It doesn't actually prevent them from typing in numbers outside the range, but now a slider appears that clearly indicates what the right values are. I also capped the values in the code.
